### PR TITLE
added repl using rustyline and added exit and reset to the repl

### DIFF
--- a/azurite_cli/Cargo.toml
+++ b/azurite_cli/Cargo.toml
@@ -11,3 +11,5 @@ azurite_compiler = { path = "../azurite_compiler" }
 azurite_runtime = { path = "../azurite_runtime" }
 zip = { version = "0.6.4", default-features = false }
 colored = "*"
+rustyline = "11.0.0"
+rustyline-derive = "0.8.0"


### PR DESCRIPTION
the repl has history and can exit with the "exit" keyword. can also reset the file with the "reset" keyword.

this will create a file called "repl.az" in order to run and compile while using the repl.